### PR TITLE
Fixed float parsing breaking on some systems.

### DIFF
--- a/src/ACT.TPMonitor/Util.cs
+++ b/src/ACT.TPMonitor/Util.cs
@@ -207,7 +207,13 @@ namespace ACT.TPMonitor
 
         private static float GetFloat(string v)
         {
-            return float.Parse(v, System.Globalization.CultureInfo.InvariantCulture);
+            if (v.IndexOf(".") > 0)
+                return float.Parse(v, System.Globalization.CultureInfo.InvariantCulture);
+            else
+            {
+                System.Globalization.CultureInfo cultureFr = new System.Globalization.CultureInfo("fr-fr");
+                return float.Parse(v, cultureFr);
+            }
         }
 
         public static bool IsActive(IntPtr hWnd)

--- a/src/ACT.TPMonitor/Util.cs
+++ b/src/ACT.TPMonitor/Util.cs
@@ -207,13 +207,7 @@ namespace ACT.TPMonitor
 
         private static float GetFloat(string v)
         {
-            if (v.IndexOf(".") > 0)
-                return float.Parse(v);
-            else
-            {
-                System.Globalization.CultureInfo cultureFr = new System.Globalization.CultureInfo("fr-fr");
-                return float.Parse(v, cultureFr);
-            }
+            return float.Parse(v, System.Globalization.CultureInfo.InvariantCulture);
         }
 
         public static bool IsActive(IntPtr hWnd)


### PR DESCRIPTION
Float parsing broke on systems where the
default decimal separator was not ".".

Previous fix only fixed french version;
this fix should apply for all versions.