### PR TITLE
Add custom ability cooldowns

### DIFF
--- a/src/ACT.TPMonitor/FFXIVPluginHelper.cs
+++ b/src/ACT.TPMonitor/FFXIVPluginHelper.cs
@@ -123,6 +123,8 @@ namespace ACT.TPMonitor
 
                         Combatant combatant = new Combatant();
 
+                        fi = temp.GetType().GetField("ID", BindingFlags.Public | BindingFlags.Instance);
+                        combatant.ID = (uint)fi.GetValue(temp);
                         fi = temp.GetType().GetField("Job", BindingFlags.Public | BindingFlags.Instance);
                         combatant.Job = (int)fi.GetValue(temp);
                         fi = temp.GetType().GetField("Name", BindingFlags.Public | BindingFlags.Instance);
@@ -153,5 +155,6 @@ namespace ACT.TPMonitor
         public int CurrentMP;
         public int MaxMP;
         public int CurrentTP;
+        public Dictionary<string, DateTime> CooldownMap;
     }
 }

--- a/src/ACT.TPMonitor/Util.cs
+++ b/src/ACT.TPMonitor/Util.cs
@@ -192,6 +192,8 @@ namespace ACT.TPMonitor
                             }
                             y += _screenRect.Top;
 
+                            // Add room for cooldowns.
+                            width += 200;
 
                             widget.Rect = new Rectangle(new Point(x, y), new Size(width, height));
                             widget.Scale = widgetScale;


### PR DESCRIPTION
This adds a new custom command called "watch" which can be used to track
cooldowns used by other party members.  Part of knowing other people's
TP is also about knowing when their invigorate cooldown is up next, but
it's also useful to see goad and swiftcast cooldowns too.

An example usage of watch is the following:

  /e TP /watch Invigorate:inv:120

This adds a cooldown for 120 seconds for the skill named Invigorate.
It will display the cooldown next to the party members name with the
remaining seconds and the "inv" short name above it.

It is intended that users just add these cooldowns to their macro
that they use to enable the TP plugin.